### PR TITLE
Simple Refactor

### DIFF
--- a/src/main/javascript/github-files.js
+++ b/src/main/javascript/github-files.js
@@ -1,34 +1,25 @@
-jQuery(document).ready(function ($) {
-  $.extend({
-    getGithubFile: function(user, repo, sha, callback, startLineNum, endLineNum) {
-      startLineNum = (typeof startLineNum == "undefined") ? 1 : startLineNum
-      endLineNum = (typeof endLineNum == "undefined") ? 0 : endLineNum
-    
-      var url = "https://api.github.com/repos/" + user + "/" + repo + "/git/blobs/" + sha
-    
+;(function ($) {
+  var fnSuccess =
+    function (data, startLineNum, endLineNum, callback) {
+      if (data.data.content && data.data.encoding === "base64") {
+        var contentArray = 
+          window
+            .atob(data.data.content.replace(/\n/g, ""))
+            .split("\n");
+
+        endLineNum = endLineNum || contentArray.length;
+
+        callback(contentArray.slice(startLineNum - 1, endLineNum).join("\n"));
+      }
+    };
+
+  $.getGithubFile =
+    function(user, repo, sha, callback, startLineNum, endLineNum) {
       $.ajax({
-        type: "GET",
-        url: url,
-        dataType: "jsonp",
-        success: function(data) {
-          if (typeof data.data.content != "undefined") {
-            if (data.data.encoding == "base64") {
-              var base64EncodedContent = data.data.content
-              base64EncodedContent = base64EncodedContent.replace(/\n/g, "")
-    
-              var content = window.atob(base64EncodedContent)
-    
-              var contentArray = content.split("\n")
-    
-              if (endLineNum == 0) {
-                endLineNum = contentArray.length
-              }
-    
-              callback(contentArray.slice(startLineNum - 1, endLineNum).join("\n"))
-            }
-          }
-        }
-      })
-    }
-  })
-})
+         type: "GET"
+        ,url: "https://api.github.com/repos/" + user + "/" + repo + "/git/blobs/" + sha
+        ,dataType: "jsonp"
+        ,success: function(data) {fnSuccess(data, +startLineNum || 1, +endLineNum || 0, callback);}
+      });
+    };
+}(jQuery));


### PR DESCRIPTION
I simplified a lot of the code to be easier to read and understand (I think?).
1. Abstracting out the success function body should provide a little bit of a performance boost since it doesn't need to be defined in each call to getGithubFile.
2. I removed the .ready portion since defining the plugin doesn't depend on the DOM being loaded.
3. I left the method on the jQuery object directly since I didn't want to refactor the tests at all.
4. Everything is pretty much a one-liner now.

The success function could be further refined if you wanted to use Function.bind and there would be further performance increase - albeit not perceptible to user in most cases. I think that some functionality would be better refactored out to data-attributes in the DOM to alleviate multiple function calls to getGithubFile - so that you could call into it once per page load instead of for each instance on the page. I would like to continue working with you on this if you would like me to.
