### PR TITLE
Allow content to be pulled from a filePath, also cache the calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ Examples:
 To get the sha for a file in git run something like:
 
     git rev-parse HEAD:README.md
+
+or use the `$.getGithubFileByFilePath` method as documented above.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ API:
 
     $.getGithubFile(user, repo, sha, callback, startLineNum, endLineNum)
 
+or
+
+    $.getGithubFileByFilePath(user, repo, filePath, callback, startLineNum, endLineNum)
+
 Examples:
 
     // fetch this README.md file and return all of the lines
@@ -25,6 +29,11 @@ Examples:
     $.getGithubFile("jamesward", "github-files", "2e7bf4aa35758d7a9cf87549d6299e924737ff05", function(contents) {
         console.log(contents)
     }, 6, 15);
+
+    // fetch this README.md file and return all of the lines
+    $.getGithubFileByFilePath("jamesward", "github-files", "README.md", function(contents) {
+        console.log(contents)
+    });
 
 To get the sha for a file in git run something like:
 

--- a/src/main/javascript/github-files.js
+++ b/src/main/javascript/github-files.js
@@ -13,6 +13,18 @@
       }
     };
 
+  $.getGithubFileByFilePath =
+    function(user, repo, filePath, callback, startLineNum, endLineNum) {
+      $.ajax({
+        type: "GET"
+        ,url: "https://api.github.com/repos/" + user + "/" + repo + "/contents/"+filePath
+        ,dataType: "jsonp"
+        ,success: function(data){
+          $.getGithubFile(user, repo, data.data.sha, callback, startLineNum, endLineNum)
+        }
+      });
+    };
+
   $.getGithubFile =
     function(user, repo, sha, callback, startLineNum, endLineNum) {
       $.ajax({

--- a/src/main/javascript/github-files.js
+++ b/src/main/javascript/github-files.js
@@ -17,11 +17,10 @@
     };
 
   $.getGithubFileByFilePath =
-    function(user, repo, filePath, cacheIt, callback, startLineNum, endLineNum) {
-      if(cacheIt && githubCacheFilePath[filePath]){
+    function(user, repo, filePath, callback, startLineNum, endLineNum) {
+      if(githubCacheFilePath[filePath]){
           $.getGithubFile(user, repo, githubCacheFilePath[filePath], true, callback, startLineNum, endLineNum)
       }else{
-        delete githubCacheFilePath[filePath]
         $.ajax({
           type: "GET"
           ,url: "https://api.github.com/repos/" + user + "/" + repo + "/contents/"+filePath
@@ -35,11 +34,10 @@
     };
 
   $.getGithubFile =
-    function(user, repo, sha, cacheIt, callback, startLineNum, endLineNum) {
-      if(cacheIt && githubCacheSha[sha]){
+    function(user, repo, sha, callback, startLineNum, endLineNum) {
+      if(githubCacheSha[sha]){
         fnSuccess(githubCacheSha[sha], +startLineNum || 1, +endLineNum || 0, callback);
       }else{
-        delete githubCacheSha[sha]
         $.ajax({
           type: "GET"
           ,url: "https://api.github.com/repos/" + user + "/" + repo + "/git/blobs/" + sha

--- a/src/main/javascript/github-files.js
+++ b/src/main/javascript/github-files.js
@@ -19,7 +19,7 @@
   $.getGithubFileByFilePath =
     function(user, repo, filePath, callback, startLineNum, endLineNum) {
       if(githubCacheFilePath[filePath]){
-          $.getGithubFile(user, repo, githubCacheFilePath[filePath], true, callback, startLineNum, endLineNum)
+          $.getGithubFile(user, repo, githubCacheFilePath[filePath], callback, startLineNum, endLineNum)
       }else{
         $.ajax({
           type: "GET"
@@ -27,7 +27,7 @@
           ,dataType: "jsonp"
           ,success: function(data){
             githubCacheFilePath[filePath] = data.data.sha;
-            $.getGithubFile(user, repo, githubCacheFilePath[filePath], cacheIt, callback, startLineNum, endLineNum)
+            $.getGithubFile(user, repo, githubCacheFilePath[filePath], callback, startLineNum, endLineNum)
           }
         });
       }

--- a/src/main/javascript/github-files.js
+++ b/src/main/javascript/github-files.js
@@ -1,4 +1,7 @@
 ;(function ($) {
+  var githubCacheFilePath = [];
+  var githubCacheSha = [];
+
   var fnSuccess =
     function (data, startLineNum, endLineNum, callback) {
       if (data.data.content && data.data.encoding === "base64") {
@@ -14,24 +17,38 @@
     };
 
   $.getGithubFileByFilePath =
-    function(user, repo, filePath, callback, startLineNum, endLineNum) {
-      $.ajax({
-        type: "GET"
-        ,url: "https://api.github.com/repos/" + user + "/" + repo + "/contents/"+filePath
-        ,dataType: "jsonp"
-        ,success: function(data){
-          $.getGithubFile(user, repo, data.data.sha, callback, startLineNum, endLineNum)
-        }
-      });
+    function(user, repo, filePath, cacheIt, callback, startLineNum, endLineNum) {
+      if(cacheIt && githubCacheFilePath[filePath]){
+          $.getGithubFile(user, repo, githubCacheFilePath[filePath], true, callback, startLineNum, endLineNum)
+      }else{
+        delete githubCacheFilePath[filePath]
+        $.ajax({
+          type: "GET"
+          ,url: "https://api.github.com/repos/" + user + "/" + repo + "/contents/"+filePath
+          ,dataType: "jsonp"
+          ,success: function(data){
+            githubCacheFilePath[filePath] = data.data.sha;
+            $.getGithubFile(user, repo, githubCacheFilePath[filePath], cacheIt, callback, startLineNum, endLineNum)
+          }
+        });
+      }
     };
 
   $.getGithubFile =
-    function(user, repo, sha, callback, startLineNum, endLineNum) {
-      $.ajax({
-         type: "GET"
-        ,url: "https://api.github.com/repos/" + user + "/" + repo + "/git/blobs/" + sha
-        ,dataType: "jsonp"
-        ,success: function(data) {fnSuccess(data, +startLineNum || 1, +endLineNum || 0, callback);}
-      });
+    function(user, repo, sha, cacheIt, callback, startLineNum, endLineNum) {
+      if(cacheIt && githubCacheSha[sha]){
+        fnSuccess(githubCacheSha[sha], +startLineNum || 1, +endLineNum || 0, callback);
+      }else{
+        delete githubCacheSha[sha]
+        $.ajax({
+          type: "GET"
+          ,url: "https://api.github.com/repos/" + user + "/" + repo + "/git/blobs/" + sha
+          ,dataType: "jsonp"
+          ,success: function(data) {
+            githubCacheSha[sha] = data
+            fnSuccess(githubCacheSha[sha], +startLineNum || 1, +endLineNum || 0, callback);
+          }
+        });
+      }
     };
 }(jQuery));


### PR DESCRIPTION
1. Added searching by a filePath. 
   - Allows more automation around getting code-contents
   - Jekyll files could even use this to more easily embed content on a post.
2. Because of additional method, caching is more important.
   - Two method calls mean getting rate-limited twice as fast
   - If we don't always cache, we would probably need an additional method parameter. This would end up breaking existing method calls. :frowning: :-1:
